### PR TITLE
Feature: make it possible to move cards between pages

### DIFF
--- a/app/controllers/custom/admin/site_customization/cards_controller.rb
+++ b/app/controllers/custom/admin/site_customization/cards_controller.rb
@@ -1,0 +1,34 @@
+load Rails.root.join("app", "controllers", "admin", "site_customization", "cards_controller.rb")
+
+class Admin::SiteCustomization::CardsController
+
+  private
+
+    alias_method :consul_card_params, :card_params
+
+    def card_params
+      # First, get the standard permitted attributes from the original method
+      permitted_attributes = consul_card_params
+
+      # Then, check our custom dropdown's value
+      new_cardable_param = params.require(:widget_card).permit(:new_cardable_id)[:new_cardable_id]
+
+      if new_cardable_param.present?
+        if new_cardable_param == "homepage_nil"
+          # This is the crucial part:
+          # If "Homepage" was selected, forcefully set the parent attributes to nil,
+          # overriding any defaults that might have been set.
+          permitted_attributes[:cardable_type] = nil
+          permitted_attributes[:cardable_id] = nil
+        else
+          # Otherwise, parse the selection as usual
+          type, id = new_cardable_param.split('_')
+          permitted_attributes[:cardable_type] = type
+          permitted_attributes[:cardable_id] = id
+        end
+      end
+
+      # Return the final, corrected hash of attributes
+      permitted_attributes
+    end
+end

--- a/app/controllers/custom/admin/widget/cards_controller.rb
+++ b/app/controllers/custom/admin/widget/cards_controller.rb
@@ -1,0 +1,31 @@
+# 1. Load the original controller file from the Consul application
+load Rails.root.join("app", "controllers", "admin", "widget", "cards_controller.rb")
+
+# 2. Re-open the controller's class to add our customization
+class Admin::Widget::CardsController
+
+  private
+
+    # 3. Create a backup (alias) of the original `card_params` method
+    alias_method :consul_card_params, :card_params
+
+    # 4. Redefine the `card_params` method with our new logic
+    def card_params
+      # First, call the original method to get all the standard permitted attributes
+      permitted_attributes = consul_card_params
+
+      # Manually permit and retrieve our custom virtual attribute from the raw params
+      new_cardable_param = params.require(:widget_card).permit(:new_cardable_id)[:new_cardable_id]
+
+      # If our custom attribute is present, parse it and merge the real attributes
+      # into the hash that the original method prepared for us.
+      if new_cardable_param.present?
+        type, id = new_cardable_param.split('_')
+        permitted_attributes[:cardable_type] = type
+        permitted_attributes[:cardable_id] = id
+      end
+
+      # Return the final, modified hash
+      permitted_attributes
+    end
+end

--- a/app/helpers/admin/cards_helper.rb
+++ b/app/helpers/admin/cards_helper.rb
@@ -1,0 +1,50 @@
+# app/helpers/admin/cards_helper.rb
+module Admin
+  module CardsHelper
+    # This method is already correct. It generates the full list of options.
+    def cardable_options
+      options = [["Homepage", "homepage_nil"]]
+
+      cardable_classes.each do |klass|
+        klass.all.each do |record|
+          options << [
+            display_name_for_cardable(record),
+            "#{record.class.name}_#{record.id}"
+          ]
+        end
+      end
+
+      options
+    end
+
+    # ==> ADD THIS NEW HELPER METHOD <==
+    # It determines which option should be pre-selected in the dropdown.
+    def selected_cardable_option(card)
+      if card.cardable_id.nil?
+        "homepage_nil"
+      else
+        "#{card.cardable_type}_#{card.cardable_id}"
+      end
+    end
+
+    private
+
+    def cardable_classes
+      Rails.application.eager_load!
+      ApplicationRecord.descendants.select do |klass|
+        klass.included_modules.include?(Cardable) && !klass.abstract_class?
+      end
+    end
+
+    def display_name_for_cardable(record)
+      prefix = record.class.model_name.human
+      if record.respond_to?(:title) && record.title.present?
+        "#{prefix}: #{record.title}"
+      elsif record.respond_to?(:name) && record.name.present?
+        "#{prefix}: #{record.name}"
+      else
+        "#{prefix} ##{record.id}"
+      end
+    end
+  end
+end

--- a/app/models/widget/card.rb
+++ b/app/models/widget/card.rb
@@ -2,6 +2,9 @@ class Widget::Card < ApplicationRecord
   include Imageable
   belongs_to :cardable, polymorphic: true
 
+   attr_accessor :new_cardable_id
+
+
   translates :label,       touch: true
   translates :title,       touch: true
   translates :description, touch: true

--- a/app/views/custom/admin/widget/cards/_form.html.erb
+++ b/app/views/custom/admin/widget/cards/_form.html.erb
@@ -1,0 +1,68 @@
+<%= render "shared/globalize_locales", resource: card %>
+
+<%= translatable_form_for [namespace.to_sym, card.cardable, card], url: local_assigns[:url] do |f| %>
+  <%= render "shared/errors", resource: card %>
+
+  <div class="row">
+    <%= f.translatable_fields do |translations_form| %>
+      <div class="small-12 medium-6 column end">
+        <%= translations_form.text_field :label %>
+      </div>
+
+      <div class="column">
+        <%= translations_form.text_field :title %>
+      </div>
+
+      <div class="column">
+        <%= translations_form.text_area :description, rows: 5 %>
+      </div>
+
+      <div class="small-12 medium-6 column end">
+        <%= translations_form.text_field :link_text %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="row">
+    <div class="small-12 medium-6 column">
+      <%= f.text_field :link_url %>
+    </div>
+  </div>
+
+  <div class="row">
+    <% unless card.header_or_sdg_header? %>
+      <div class="small-12 medium-6 column">
+        <%= f.select :columns, (1..12), hint: t("admin.site_customization.pages.cards.columns_help") %>
+      </div>
+
+      <div class="small-12 medium-6 column">
+        <%= f.number_field :order, min: 1, hint: t("admin.site_customization.pages.cards.order_help") %>
+      </div>
+    <% end %>
+  </div>
+  
+  <div class="row">
+    <div class="small-12 medium-6 column">
+      <%= f.select :new_cardable_id,
+                   options_for_select(cardable_options, selected_cardable_option(card)),
+                 {  label: "Parent Page",
+                  hint: "Select the custom page this card belongs to." } %>
+    </div>
+
+  </div>
+
+  <%= f.hidden_field :header, value: card.header? %>
+  <div class="row">
+    <div class="image-form">
+      <div class="image small-12 column">
+        <%= render Images::NestedComponent.new(f) %>
+      </div>
+    </div>
+    <div class="column">
+      <%= f.submit(
+        t("admin.homepage.#{admin_submit_action(card)}.#{card.header_or_sdg_header? ? "submit_header" : "submit_card"}"),
+        class: "button success"
+      ) %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
This PR adds a drop down list on the Edit Card page which allows you to select which page the card is attached to

<img width="1410" height="1158" alt="image" src="https://github.com/user-attachments/assets/1d16e183-1354-4e7e-a35b-3182cd5d3ace" />

A useful tip, to make a bank of reusable cards, create a custom page, attach cards to it and then you can bring them out of retirement when needs be
