### PR TITLE
Conditional email delivery in publish method

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -93,7 +93,7 @@ class Proposal < ApplicationRecord
 
   def publish
     update!(published_at: Time.current)
-    Mailer.proposal_published(self).deliver_later
+    Mailer.proposal_published(self).deliver_later unless Setting["feature.dashboard.notification_emails"]
     send_new_actions_notification_on_published
   end
 


### PR DESCRIPTION
Use the Dashboard Notification feature to toggle between short email on Proposal publish or long email on both create and publish